### PR TITLE
(REPLATS-662) Adding Trivy scan for vulnerability checking

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,31 @@
+name: Trivy security scan
+
+on:
+  schedule:
+  # Run every weekday at 8am
+  - cron: '0 7 * * 1-5'
+
+jobs:
+  build:
+    name: Scan
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Pull image from Dockerfile.release
+        run: |
+          echo "IMAGE=$(grep -o 'FROM.*' Dockerfile.release | cut -f 2 -d ' ')" >> $GITHUB_ENV
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.IMAGE }}'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Dockerfile and image scanning is being transitioned to Trivy.  This commit adds a scheduled Trivy check of the upstream image used for the minio release.  The security scan results will appear in the "Security" tab of Github.