### PR TITLE
Use RHEL ubi-minimal:8.5 to address CVEs

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 ARG TARGETARCH
 

--- a/docker-buildx.sh
+++ b/docker-buildx.sh
@@ -1,21 +1,8 @@
 #!/bin/bash
 
-sudo sysctl net.ipv6.conf.wlp59s0.disable_ipv6=1
-
 release=$(git describe --abbrev=0 --tags)
 
 docker buildx build --push --no-cache \
-       --build-arg RELEASE="${release}" -t "minio/minio:latest" \
-       --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x \
-       -f Dockerfile.release .
+       --build-arg RELEASE="${release}" -t "gcr.io/platform-services-297419/minio:${release}" \
+       --platform=linux/amd64 -f Dockerfile.release .
 
-docker buildx prune -f
-
-docker buildx build --push --no-cache \
-       --build-arg RELEASE="${release}" -t "minio/minio:${release}" \
-       --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x \
-       -f Dockerfile.release .
-
-docker buildx prune -f
-
-sudo sysctl net.ipv6.conf.wlp59s0.disable_ipv6=0


### PR DESCRIPTION
Uses RHEL ubi-minimal:8.5 to address CVEs in 8.3. Updates build process
for quick local builds for linux/amd64 (the only runtime we support).

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
